### PR TITLE
-This fixes an issue when using PerformanceCounters in ASP.Net applic…

### DIFF
--- a/src/Akka.Monitoring.PerformanceCounters/ActorPerformanceCountersMonitor.cs
+++ b/src/Akka.Monitoring.PerformanceCounters/ActorPerformanceCountersMonitor.cs
@@ -101,15 +101,15 @@ namespace Akka.Monitoring.PerformanceCounters
             foreach (var akkaMetric in akkaMetrics)
             {
                 akkaMetric.RegisterIn(ccdc);
-            }
+            }            
 
-            if (PerformanceCounterCategory.Exists(PerformanceCountersCategoryName))
+            if (!PerformanceCounterCategory.Exists(PerformanceCountersCategoryName))
             {
-                PerformanceCounterCategory.Delete(PerformanceCountersCategoryName);
+                //Only create if it doesn't exist.
+                PerformanceCounterCategory.Create(PerformanceCountersCategoryName, "", PerformanceCounterCategoryType.MultiInstance, ccdc);
             }
 
-            PerformanceCounterCategory.Create(PerformanceCountersCategoryName, "",
-                PerformanceCounterCategoryType.MultiInstance, ccdc);
+            
         }
 
         //extracts metric object and instance name ("_total" or ActorSpecificCategory)


### PR DESCRIPTION
…ations.  The original code was attempting to delete a performance counter if it already exists.  Only to recreate it.  This caused a requirement to have permissions elevated to admin in order to run.  Instead I removed the need to delete and only create the performance counter if it doesn't already exist.

This is referencing #16 