### PR TITLE
PerformanceCountersCategoryName made settable

### DIFF
--- a/src/Akka.Monitoring.PerformanceCounters/ActorPerformanceCountersMonitor.cs
+++ b/src/Akka.Monitoring.PerformanceCounters/ActorPerformanceCountersMonitor.cs
@@ -8,9 +8,10 @@ namespace Akka.Monitoring.PerformanceCounters
 {
     public class ActorPerformanceCountersMonitor : AbstractActorMonitoringClient
     {
-        internal const string PerformanceCountersCategoryName = "Akka";
+        internal static string PerformanceCountersCategoryName { get; set; }
+
         private const string TotalCounterInstanceName = "_Total";
-        private static readonly Guid MonitorName = new Guid("F651B9F8-AA38-45BD-BFB9-C5595519C23C");        
+        private static readonly Guid MonitorName = new Guid("F651B9F8-AA38-45BD-BFB9-C5595519C23C");
         private static readonly HashSet<string> BuiltInCounterNames = new HashSet<string>(new[]
         {
             CounterNames.ActorRestarts,
@@ -24,34 +25,36 @@ namespace Akka.Monitoring.PerformanceCounters
             CounterNames.WarningMessages,
             CounterNames.ErrorMessages,
         });
-        
+
         private readonly Dictionary<string, AkkaCounter> _counters;
         private readonly Dictionary<string, AkkaGauge> _gauges;
         private readonly Dictionary<string, AkkaTimer> _timers;
 
-        public ActorPerformanceCountersMonitor(CustomMetrics customMetrics =null)
+        public ActorPerformanceCountersMonitor(CustomMetrics customMetrics = null, string categoryName = "Akka")
         {
+            PerformanceCountersCategoryName = categoryName;
+
             var counterNames = BuiltInCounterNames;
             var gaugeNames = new HashSet<string>();
             var timerNames = new HashSet<string>();
             if (customMetrics != null)
             {
-                counterNames = new HashSet<string>(counterNames.Concat(customMetrics.Counters));                
+                counterNames = new HashSet<string>(counterNames.Concat(customMetrics.Counters));
                 gaugeNames = customMetrics.Gauges;
                 timerNames = customMetrics.Timers;
             }
-            _counters = counterNames.ToDictionary(cn => cn, cn=>new AkkaCounter(cn));
-            _gauges = gaugeNames.ToDictionary(cn => cn, cn=>new AkkaGauge(cn));
+            _counters = counterNames.ToDictionary(cn => cn, cn => new AkkaCounter(cn));
+            _gauges = gaugeNames.ToDictionary(cn => cn, cn => new AkkaGauge(cn));
             _timers = timerNames.ToDictionary(cn => cn, cn => new AkkaTimer(cn));
             Init(_counters.Values.Cast<AkkaMetric>().Concat(_gauges.Values).Concat(_timers.Values));
         }
 
         public override void UpdateCounter(string metricName, int delta, double sampleRate)
-        {                      
-            var resolution = ResolveMetricInstance(metricName,_counters);
+        {
+            var resolution = ResolveMetricInstance(metricName, _counters);
             if (resolution != null)
             {
-                resolution.Item1.Update(resolution.Item2,delta);
+                resolution.Item1.Update(resolution.Item2, delta);
             }
             else
             {

--- a/src/Akka.Monitoring.PerformanceCounters/ActorPerformanceCountersMonitor.cs
+++ b/src/Akka.Monitoring.PerformanceCounters/ActorPerformanceCountersMonitor.cs
@@ -8,7 +8,7 @@ namespace Akka.Monitoring.PerformanceCounters
 {
     public class ActorPerformanceCountersMonitor : AbstractActorMonitoringClient
     {
-        internal static string PerformanceCountersCategoryName { get; set; }
+        internal static string PerformanceCountersCategoryName { get; private set; }
 
         private const string TotalCounterInstanceName = "_Total";
         private static readonly Guid MonitorName = new Guid("F651B9F8-AA38-45BD-BFB9-C5595519C23C");

--- a/src/Akka.Monitoring.PerformanceCounters/AkkaCounter.cs
+++ b/src/Akka.Monitoring.PerformanceCounters/AkkaCounter.cs
@@ -8,8 +8,8 @@ namespace Akka.Monitoring.PerformanceCounters
     {
         readonly ConcurrentDictionary<string, Tuple<PerformanceCounter, PerformanceCounter>> _performanceCounters =
             new ConcurrentDictionary<string, Tuple<PerformanceCounter, PerformanceCounter>>();
-        public AkkaCounter(string name)
-            :base(name)
+        public AkkaCounter(string name, string categoryName)
+            : base(name, categoryName)
         {            
         }        
 
@@ -35,10 +35,8 @@ namespace Akka.Monitoring.PerformanceCounters
             if (!_performanceCounters.ContainsKey(instanceName))
             {
                 _performanceCounters.TryAdd(instanceName, Tuple.Create(
-                    new PerformanceCounter(ActorPerformanceCountersMonitor.PerformanceCountersCategoryName, Name,
-                        instanceName, false),
-                    new PerformanceCounter(ActorPerformanceCountersMonitor.PerformanceCountersCategoryName,
-                        RatePerformanceCounterName(Name), instanceName, false)));
+                    new PerformanceCounter(CategoryName, Name, instanceName, false),
+                    new PerformanceCounter(CategoryName, RatePerformanceCounterName(Name), instanceName, false)));
             }
 
             _performanceCounters[instanceName].Item1.IncrementBy(delta);

--- a/src/Akka.Monitoring.PerformanceCounters/AkkaGauge.cs
+++ b/src/Akka.Monitoring.PerformanceCounters/AkkaGauge.cs
@@ -7,7 +7,7 @@ namespace Akka.Monitoring.PerformanceCounters
     {
         readonly ConcurrentDictionary<string, PerformanceCounter> _performanceCounters =
             new ConcurrentDictionary<string, PerformanceCounter>();
-        public AkkaGauge(string name) : base(name)
+        public AkkaGauge(string name, string categoryName) : base(name, categoryName)
         {
         }
 
@@ -27,8 +27,7 @@ namespace Akka.Monitoring.PerformanceCounters
             if (!_performanceCounters.ContainsKey(instanceName))
             {
                 _performanceCounters.TryAdd(instanceName,
-                    new PerformanceCounter(ActorPerformanceCountersMonitor.PerformanceCountersCategoryName, Name, instanceName,
-                        false));
+                    new PerformanceCounter(CategoryName, Name, instanceName, false));
             }
             _performanceCounters[instanceName].RawValue = value;
         }

--- a/src/Akka.Monitoring.PerformanceCounters/AkkaMetric.cs
+++ b/src/Akka.Monitoring.PerformanceCounters/AkkaMetric.cs
@@ -5,15 +5,22 @@ namespace Akka.Monitoring.PerformanceCounters
     internal abstract class AkkaMetric
     {
         private readonly string _name;
+        private readonly string _categoryName;
 
-        protected AkkaMetric(string name)
+        protected AkkaMetric(string name, string categoryName)
         {
             _name = name;
+            _categoryName = categoryName;
         }
 
         public string Name
         {
             get { return _name; }
+        }
+
+        public string CategoryName
+        {
+            get { return _categoryName; }
         }
 
         abstract public void RegisterIn(CounterCreationDataCollection collection);

--- a/src/Akka.Monitoring.PerformanceCounters/AkkaTimer.cs
+++ b/src/Akka.Monitoring.PerformanceCounters/AkkaTimer.cs
@@ -9,8 +9,8 @@ namespace Akka.Monitoring.PerformanceCounters
         private readonly ConcurrentDictionary<string, Tuple<PerformanceCounter, PerformanceCounter>>
             _performanceCounters = new ConcurrentDictionary<string, Tuple<PerformanceCounter, PerformanceCounter>>();
 
-        public AkkaTimer(string name)
-            : base(name)
+        public AkkaTimer(string name, string categoryName)
+            : base(name, categoryName)
         {
         }
 
@@ -36,10 +36,8 @@ namespace Akka.Monitoring.PerformanceCounters
             if (!_performanceCounters.ContainsKey(instanceName))
             {
                 _performanceCounters.TryAdd(instanceName, Tuple.Create(
-                    new PerformanceCounter(ActorPerformanceCountersMonitor.PerformanceCountersCategoryName, Name,
-                        instanceName, false),
-                    new PerformanceCounter(ActorPerformanceCountersMonitor.PerformanceCountersCategoryName,
-                        Name + "Base", instanceName, false)
+                    new PerformanceCounter(CategoryName, Name, instanceName, false),
+                    new PerformanceCounter(CategoryName, Name + "Base", instanceName, false)
                     ));
             }
             _performanceCounters[instanceName].Item1.IncrementBy(value);


### PR DESCRIPTION
This pull request makes possible to set a performance counters category name in ActorPerformanceCountersMonitor constructor. If not provided in constructor, a default name "Akka" is used as before. 